### PR TITLE
fix: #28 input empty rendering

### DIFF
--- a/admin/src/components/InputEmptyButton/index.tsx
+++ b/admin/src/components/InputEmptyButton/index.tsx
@@ -13,16 +13,16 @@ export type InputEmptyButtonProps = {
 export default function InputEmptyButton({ onImport }: InputEmptyButtonProps) {
   return (
     <CarouselInput label="" nextLabel="" previousLabel="" selectedSlide={0}>
-      <ImportModal entry={null} onImport={onImport}>
-        <CarouselSlide label="" style={{ cursor: 'pointer' }}>
+      <CarouselSlide label="" style={{ cursor: 'pointer' }}>
+        <ImportModal entry={null} onImport={onImport}>
           <Flex direction="column" gap="12px" alignItems="center">
             <PlusCircle aria-hidden width="3.2em" height="3.2em" fill="primary600" />
             <Typography variant="pi" fontWeight="bold" textColor="neutral600">
               <FormattedMessage id={getTranslation('form.button.import')} />
             </Typography>
           </Flex>
-        </CarouselSlide>
-      </ImportModal>
+        </ImportModal>
+      </CarouselSlide>
     </CarouselInput>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-oembed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-oembed",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-oembed",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Embed content from third-party sites in Strapi",
   "keywords": [
     "strapi",


### PR DESCRIPTION
Fixes #28 

When running in development mode, this wasn't coming up as an issue; however, it seems that CarouselInput must have CarouselSlide as direct children. This PR re-orders the components to put the input modal as a child of the slide.