### PR TITLE
fix: follow app theme

### DIFF
--- a/admin/src/components/Input/index.tsx
+++ b/admin/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { DesignSystemProvider, Field } from '@strapi/design-system';
+import { Field } from '@strapi/design-system';
 
 import { type Oembed } from '@/shared/types/oembed';
 
@@ -33,16 +33,14 @@ export default function Input({ error = undefined, name, label, onChange, value 
   };
 
   return (
-    <DesignSystemProvider>
-      <Field.Root name="oembed" error={error}>
-        <Field.Label>{label}</Field.Label>
+    <Field.Root name="oembed" error={error}>
+      <Field.Label>{label}</Field.Label>
 
-        {!hasValue && <InputEmptyButton onImport={handleImport} />}
-        {hasValue && <InputOembedCard entry={value} onImport={handleImport} />}
+      {!hasValue && <InputEmptyButton onImport={handleImport} />}
+      {hasValue && <InputOembedCard entry={value} onImport={handleImport} />}
 
-        <Field.Hint />
-        <Field.Error />
-      </Field.Root>
-    </DesignSystemProvider>
+      <Field.Hint />
+      <Field.Error />
+    </Field.Root>
   );
 }


### PR DESCRIPTION
The plugin was not following the app theme because of the provider.

<img width="1654" height="810" alt="Screenshot 2026-07-21 at 20 54 17" src="https://github.com/user-attachments/assets/c9cacb6a-fede-409a-84ee-709eafba0648" />