### PR TITLE
chore: use latest npm to publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      # Can be removed once moved to Node.js 24+ LTS
+      - name: upgrade
+        run: npm install -g npm@latest
+
       - name: install
         run: npm ci
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,10 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      # Can be removed once moved to Node.js 24+ LTS
+      - name: upgrade
+        run: npm install -g npm@latest
+
       - name: install
         run: npm ci
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,5 +28,9 @@ jobs:
       - name: build
         run: npm run build
 
+      # Publish to npmjs using a newer version of npm, as
+      # Node.js v22 (required by the Strapi plugin API) ships
+      # with npm 10 and npm 11 is required to use OIDC
+
       - name: publish
-        run: npm publish --access public --provenance
+        run: npx npm@latest publish --access public --provenance

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,9 @@ jobs:
       # Publish to npmjs using a newer version of npm, as
       # Node.js v22 (required by the Strapi plugin API) ships
       # with npm 10 and npm 11 is required to use OIDC
+      # Upgrades the global binary inside the runner explicitly
+      - name: upgrade
+        run: npm install -g npm@latest
 
       - name: publish
-        run: npx npm@latest publish --access public --provenance
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
       # Publish to npmjs using a newer version of npm, as
       # Node.js v22 (required by the Strapi plugin API) ships
       # with npm 10 and npm 11 is required to use OIDC
-      # Upgrades the global binary inside the runner explicitly
+      # Can be removed once moved to Node.js 24+ LTS
       - name: upgrade
         run: npm install -g npm@latest
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,18 +22,18 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
-      - name: install
-        run: npm ci
-
-      - name: build
-        run: npm run build
-
       # Publish to npmjs using a newer version of npm, as
       # Node.js v22 (required by the Strapi plugin API) ships
       # with npm 10 and npm 11 is required to use OIDC
       # Upgrades the global binary inside the runner explicitly
       - name: upgrade
         run: npm install -g npm@latest
+
+      - name: install
+        run: npm ci
+
+      - name: build
+        run: npm run build
 
       - name: publish
         run: npm publish --access public --provenance


### PR DESCRIPTION
Publish to npmjs using a newer version of npm, as Node.js v22 (required by the Strapi plugin API) ships with npm 10 and npm 11 is required to use OIDC