### PR TITLE
chore: update strapi design system and icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@extractus/oembed-extractor": "^4.0.7",
-        "@strapi/design-system": "^2.0.0-rc.23",
-        "@strapi/icons": "^2.0.0-rc.23",
+        "@strapi/design-system": "^2",
+        "@strapi/icons": "^2",
         "react-intl": "^7.1.10"
       },
       "devDependencies": {
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
-      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -322,12 +322,13 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.36.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.5.tgz",
-      "integrity": "sha512-cd+FZEUlu3GQCYnguYm3EkhJ8KJVisqqUsCOKedBoAt/d9c76JUUap6U0UrpElln5k6VyrEOYliMuDAKIeDQLg==",
+      "version": "6.43.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -6098,12 +6099,14 @@
       }
     },
     "node_modules/@strapi/design-system": {
-      "version": "2.0.0-rc.23",
-      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.23.tgz",
-      "integrity": "sha512-PXWVlNqA4GDPxx8B2r7LFuQtWgGgjnPXnCOZhynpqqEVVcFkrYmRCPALFhHPD4J3hpEadlUinvlcisMymVviUw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.2.4.tgz",
+      "integrity": "sha512-ypr5tKyv8pzJJ7IX7DKEG44chT0+mDywpEsbX1FxU9I/PxVGtayU+wVsfl5NiBfLDrKutDUKxWLZ1NvMfk+JtA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-json": "6.0.1",
+        "@codemirror/state": "6.7.1",
+        "@codemirror/view": "6.43.0",
         "@floating-ui/react-dom": "2.1.0",
         "@internationalized/date": "3.5.4",
         "@internationalized/number": "3.5.3",
@@ -6124,17 +6127,24 @@
         "@radix-ui/react-tabs": "1.0.4",
         "@radix-ui/react-tooltip": "1.0.7",
         "@radix-ui/react-use-callback-ref": "1.0.1",
-        "@strapi/ui-primitives": "2.0.0-rc.23",
+        "@strapi/ui-primitives": "2.2.4",
+        "@tanstack/react-virtual": "^3.10.8",
         "@uiw/react-codemirror": "4.22.2",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "react-remove-scroll": "2.5.10"
       },
       "peerDependencies": {
         "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "styled-components": "^6.0.0"
       }
+    },
+    "node_modules/@strapi/design-system/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/@strapi/design-system/node_modules/react-remove-scroll": {
       "version": "2.5.10",
@@ -6769,13 +6779,13 @@
       }
     },
     "node_modules/@strapi/icons": {
-      "version": "2.0.0-rc.23",
-      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.0.0-rc.23.tgz",
-      "integrity": "sha512-sJ7iQ8kZ28z3mTkDm/gnsWIQljK3w0UaOk2irO77iSmbh+uR3W9gDF5CP/4Z+KDUqnjDke2kaOIPRI67etvi9A==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-ul/NwHl1JiHb5OGXUoSNOIh/jfunAGVpehNvlQcp4P3B2Qb655uuldIe/Eg+8MLcd7VRUwRAckReuL7z1mT6RQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "styled-components": "^6.0.0"
       }
     },
@@ -8379,9 +8389,9 @@
       }
     },
     "node_modules/@strapi/ui-primitives": {
-      "version": "2.0.0-rc.23",
-      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.23.tgz",
-      "integrity": "sha512-YMH9z0k/aX8HYrq+sDCc5v2cPPqRBwgzQ/NxkzV1pvqvonKFgH3V3sQTXM3tStVkz4z4RuxB/lXoEZXGe/aVdg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.2.4.tgz",
+      "integrity": "sha512-v0VmJ3BkE7Kht9o/DXrTI6Qz+IJzZ/Fc/1D6JRLp7nbCaFkBFjuBMHUvjpS+nLh9C1YfaYtGF6Snr0/ONjPDUQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.0.1",
@@ -8393,7 +8403,6 @@
         "@radix-ui/react-dismissable-layer": "1.0.5",
         "@radix-ui/react-focus-guards": "1.0.1",
         "@radix-ui/react-focus-scope": "1.0.4",
-        "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-popper": "1.1.3",
         "@radix-ui/react-portal": "1.0.4",
         "@radix-ui/react-primitive": "1.0.3",
@@ -8402,12 +8411,13 @@
         "@radix-ui/react-use-layout-effect": "1.0.1",
         "@radix-ui/react-use-previous": "1.0.1",
         "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
         "aria-hidden": "1.2.4",
         "react-remove-scroll": "2.5.10"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@strapi/ui-primitives/node_modules/react-remove-scroll": {
@@ -9108,6 +9118,33 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -18097,6 +18134,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   },
   "dependencies": {
     "@extractus/oembed-extractor": "^4.0.7",
-    "@strapi/design-system": "^2.0.0-rc.23",
-    "@strapi/icons": "^2.0.0-rc.23",
+    "@strapi/design-system": "^2",
+    "@strapi/icons": "^2",
     "react-intl": "^7.1.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Update @strapi/design-system and @strapi/icons to use version 2 and avoid the pre-releases